### PR TITLE
Fix Aethercast FTBFS & avoid waiting for upstart-property-watcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ pkg_check_modules(GIO-UNIX REQUIRED gio-unix-2.0)
 pkg_check_modules(WDS REQUIRED wds)
 pkg_check_modules(MIRCLIENT REQUIRED mirclient)
 pkg_check_modules(HYBRIS_MEDIA REQUIRED libmedia)
-pkg_check_modules(ANDROID_HEADERS REQUIRED android-headers)
+pkg_check_modules(ANDROID_HEADERS REQUIRED android-headers-19)
 
 include(cmake/EnableCoverageReport.cmake)
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/conf/aethercast.conf.in
+++ b/conf/aethercast.conf.in
@@ -8,7 +8,11 @@ respawn
 script
 	if [ -f /system/build.prop ] ; then
 		# Wait for Android properties to be set
-		while [ "$(getprop init.svc.upstart-watcher)" != "running" ]; do sleep 0.2; done
+		# In theory we can wait for the socket to show up. However, the read of
+		# system properties can happen a bit later. Instead, wait for
+		# "wifi.interface" property, which is usually set together with
+		# "wifi.direct.interface" (if it's set).
+		while [ -z "$(getprop wifi.interface)" ]; do sleep 0.2; done
 
 		iface=`getprop wifi.direct.interface`
 		if [ "$iface" != "" ] ; then


### PR DESCRIPTION
This PR does 3 things:
- It updates `Jenkinsfile` to prevent aptly failure.
- It fixes `android-headers` `pkg-config` package name to versioned variant.
- It changes the wait for `upstart-property-watcher` to the wait for `wifi.interface` property.

These fixes, along with ubports/wds#2, make the package build again.

Requires https://github.com/ubports/wds/pull/2.