### PR TITLE
android9: Performance improvements for 720p & hang fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/conf/aethercast.conf.in
+++ b/conf/aethercast.conf.in
@@ -1,6 +1,6 @@
 description "Display cast service"
 
-start on started dbus and started urfkill
+start on started dbus and started urfkill and started lightdm
 stop on stopping dbus
 
 respawn

--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -220,7 +220,6 @@ bool H264Encoder::Configure(const Config &config) {
     media_message_set_int32(format, kFormatKeyBitrateMode, kOMXVideoControlRateConstant);
     media_message_set_int32(format, kFormatKeyFramerate, config.framerate);
 
-#if 0
     media_message_set_int32(format, kFormatKeyIntraRefreshMode, 0);
 
     // Update macroblocks in a cyclic fashion with 10% of all MBs within
@@ -230,7 +229,6 @@ bool H264Encoder::Configure(const Config &config) {
     // to recover from a lost/corrupted packet.
     const int32_t mbs = (((config.width + 15) / 16) * ((config.height + 15) / 16) * 10) / 100;
     media_message_set_int32(format, kFormatKeyIntraRefreshCIRMbs, mbs);
-#endif
 
     if (config.i_frame_interval > 0)
         media_message_set_int32(format, kFormatKeyIFrameInterval, config.i_frame_interval);

--- a/src/ac/mediamanagerfactory.cpp
+++ b/src/ac/mediamanagerfactory.cpp
@@ -56,6 +56,8 @@ bool NullSourceMediaManager::Configure() {
     return false;
 }
 
+static const auto screencast = std::make_shared<ac::mir::Screencast>();
+
 std::shared_ptr<BaseSourceMediaManager> MediaManagerFactory::CreateSource(const std::string &remote_address,
                                                                           const ac::network::Stream::Ptr &output_stream) {
     std::string type = Utils::GetEnvValue("MIRACAST_SOURCE_TYPE");
@@ -67,7 +69,6 @@ std::shared_ptr<BaseSourceMediaManager> MediaManagerFactory::CreateSource(const 
     if (type == "mir") {
         const auto executor_factory = std::make_shared<common::ThreadedExecutorFactory>();
         const auto report_factory = report::ReportFactory::Create();
-        const auto screencast = std::make_shared<ac::mir::Screencast>();
         const auto encoder = ac::android::H264Encoder::Create(report_factory->CreateEncoderReport());
 
         return std::make_shared<ac::mir::SourceMediaManager>(

--- a/src/ac/mir/screencast.cpp
+++ b/src/ac/mir/screencast.cpp
@@ -40,8 +40,13 @@ Screencast::~Screencast() {
     if (screencast_)
         mir_screencast_release_sync(screencast_);
 
+    screencast_ = nullptr;
+    buffer_stream_ = nullptr;
+
     if (connection_)
         mir_connection_release(connection_);
+
+    connection_ = nullptr;
 }
 
 bool Screencast::Setup(const video::DisplayOutput &output) {
@@ -107,8 +112,8 @@ bool Screencast::Setup(const video::DisplayOutput &output) {
     // as just another display.
     region.left = display_mode->horizontal_resolution;
     region.top = 0;
-    region.width = display_mode->vertical_resolution;
-    region.height = display_mode->horizontal_resolution;
+    region.width = output.width;
+    region.height = output.height;
 
     mir_screencast_spec_set_capture_region(spec, &region);
 

--- a/src/ac/mir/screencast.cpp
+++ b/src/ac/mir/screencast.cpp
@@ -35,22 +35,15 @@ Screencast::Screencast() :
 }
 
 Screencast::~Screencast() {
-    AC_DEBUG("");
-
-    if (screencast_)
-        mir_screencast_release_sync(screencast_);
-
-    screencast_ = nullptr;
-    buffer_stream_ = nullptr;
+    Stop();
 
     if (connection_)
         mir_connection_release(connection_);
-
     connection_ = nullptr;
 }
 
 bool Screencast::Setup(const video::DisplayOutput &output) {
-    if (screencast_ || connection_ || buffer_stream_)
+    if (screencast_ || buffer_stream_)
         return false;
 
     if (output.mode != video::DisplayOutput::Mode::kExtend) {
@@ -61,7 +54,9 @@ bool Screencast::Setup(const video::DisplayOutput &output) {
     AC_DEBUG("Setting up screencast [%s %dx%d]", output.mode,
               output.width, output.height);
 
-    connection_ = mir_connect_sync(kMirSocket, kMirConnectionName);
+    if (!connection_)
+        connection_ = mir_connect_sync(kMirSocket, kMirConnectionName);
+
     if (!mir_connection_is_valid(connection_)) {
         AC_ERROR("Failed to connect to Mir server: %s",
                   mir_connection_get_error_message(connection_));
@@ -155,6 +150,16 @@ bool Screencast::Setup(const video::DisplayOutput &output) {
     }
 
     output_ = output;
+
+    return true;
+}
+
+bool Screencast::Stop() {
+    if (screencast_)
+        mir_screencast_release_sync(screencast_);
+
+    screencast_ = nullptr;
+    buffer_stream_ = nullptr;
 
     return true;
 }

--- a/src/ac/mir/screencast.h
+++ b/src/ac/mir/screencast.h
@@ -37,6 +37,7 @@ public:
     ~Screencast();
 
     bool Setup(const video::DisplayOutput &output) override;
+    bool Stop() override;
 
     // From ac::video::BufferProducer
     void SwapBuffers() override;

--- a/src/ac/mir/sourcemediamanager.cpp
+++ b/src/ac/mir/sourcemediamanager.cpp
@@ -60,8 +60,10 @@ SourceMediaManager::SourceMediaManager(const std::string &remote_address,
 }
 
 SourceMediaManager::~SourceMediaManager() {
-    if (state_ != State::Stopped)
+    if (state_ != State::Stopped) {
+        producer_->Stop();
         pipeline_.Stop();
+    }
 }
 
 bool SourceMediaManager::Configure() {

--- a/src/ac/video/bufferproducer.h
+++ b/src/ac/video/bufferproducer.h
@@ -34,6 +34,7 @@ public:
     virtual ~BufferProducer() { }
 
     virtual bool Setup(const video::DisplayOutput &output) = 0;
+    virtual bool Stop() = 0;
     virtual void SwapBuffers() = 0;
     virtual void* CurrentBuffer() const = 0;
     virtual DisplayOutput OutputMode() const = 0;

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -374,12 +374,10 @@ TEST_F(H264EncoderFixture, CorrectConfiguration) {
             .Times(1);
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("frame-rate"), config.framerate))
             .Times(1);
-#if 0
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("intra-refresh-mode"), config.intra_refresh_mode))
             .Times(1);
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("intra-refresh-CIR-mbs"), 360))
             .Times(1);
-#endif
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("i-frame-interval"), config.i_frame_interval))
             .Times(1);
 #if 0

--- a/tests/ac/mir/screencast_tests.cpp
+++ b/tests/ac/mir/screencast_tests.cpp
@@ -167,8 +167,8 @@ TEST(Screencast, NoPixelFormatAvailable) {
 
     ac::video::DisplayOutput output;
     output.mode = ac::video::DisplayOutput::Mode::kExtend;
-    output.width = 640;
-    output.height = 480;
+    output.width = 1280;
+    output.height = 720;
 
     auto connection = reinterpret_cast<MirConnection*>(1);
 
@@ -218,8 +218,8 @@ TEST(Screencast, NoPixelFormatAvailable) {
                 boost::ignore_unused_variable_warning(spec);
                 EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->left);
                 EXPECT_EQ(0, rect->top);
-                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, rect->width);
-                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, output.height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, output.width);
             }));
 
     EXPECT_CALL(*mir, mir_connection_get_available_surface_formats(connection, _, _, _))
@@ -238,8 +238,8 @@ TEST(Screencast, ScreencastCreationFails) {
 
     ac::video::DisplayOutput output;
     output.mode = ac::video::DisplayOutput::Mode::kExtend;
-    output.width = 640;
-    output.height = 480;
+    output.width = 1280;
+    output.height = 720;
 
     auto connection = reinterpret_cast<MirConnection*>(1);
 
@@ -289,8 +289,8 @@ TEST(Screencast, ScreencastCreationFails) {
                 boost::ignore_unused_variable_warning(spec);
                 EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->left);
                 EXPECT_EQ(0, rect->top);
-                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, rect->width);
-                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, output.height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, output.width);
             }));
 
     EXPECT_CALL(*mir, mir_connection_get_available_surface_formats(connection, _, _, _))
@@ -330,8 +330,8 @@ TEST(Screencast, ScreencastDoesNotProvideBufferStream) {
 
     ac::video::DisplayOutput output;
     output.mode = ac::video::DisplayOutput::Mode::kExtend;
-    output.width = 640;
-    output.height = 480;
+    output.width = 1280;
+    output.height = 720;
 
     auto connection = reinterpret_cast<MirConnection*>(1);
 
@@ -381,8 +381,8 @@ TEST(Screencast, ScreencastDoesNotProvideBufferStream) {
                 boost::ignore_unused_variable_warning(spec);
                 EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->left);
                 EXPECT_EQ(0, rect->top);
-                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, rect->width);
-                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, output.height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, output.width);
             }));
 
     EXPECT_CALL(*mir, mir_connection_get_available_surface_formats(connection, _, _, _))
@@ -436,8 +436,8 @@ TEST(Screencast, DoesSwapBuffersAndReturnsCurrentBuffer) {
 
     ac::video::DisplayOutput output;
     output.mode = ac::video::DisplayOutput::Mode::kExtend;
-    output.width = 640;
-    output.height = 480;
+    output.width = 1280;
+    output.height = 720;
     output.refresh_rate = 30;
 
     auto connection = reinterpret_cast<MirConnection*>(1);
@@ -488,8 +488,8 @@ TEST(Screencast, DoesSwapBuffersAndReturnsCurrentBuffer) {
                 boost::ignore_unused_variable_warning(spec);
                 EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->left);
                 EXPECT_EQ(0, rect->top);
-                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, rect->width);
-                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, rect->height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].vertical_resolution, output.height);
+                EXPECT_EQ(display_config.outputs[0].modes[0].horizontal_resolution, output.width);
             }));
 
     EXPECT_CALL(*mir, mir_connection_get_available_surface_formats(connection, _, _, _))

--- a/tests/ac/mir/sourcemediamanager_tests.cpp
+++ b/tests/ac/mir/sourcemediamanager_tests.cpp
@@ -35,6 +35,7 @@ public:
 class MockBufferProducer : public ac::video::BufferProducer {
 public:
     MOCK_METHOD1(Setup, bool(const ac::video::DisplayOutput&));
+    MOCK_METHOD0(Stop, bool());
     MOCK_METHOD0(SwapBuffers, void());
     MOCK_CONST_METHOD0(CurrentBuffer, void*());
     MOCK_CONST_METHOD0(OutputMode, ac::video::DisplayOutput());

--- a/tests/ac/mir/streamrenderer_tests.cpp
+++ b/tests/ac/mir/streamrenderer_tests.cpp
@@ -27,6 +27,7 @@ namespace {
 class MockBufferProducer : public ac::video::BufferProducer {
 public:
     MOCK_METHOD1(Setup, bool(const ac::video::DisplayOutput&));
+    MOCK_METHOD0(Stop, bool());
     MOCK_METHOD0(SwapBuffers, void());
     MOCK_CONST_METHOD0(CurrentBuffer, void*());
     MOCK_CONST_METHOD0(OutputMode, ac::video::DisplayOutput());


### PR DESCRIPTION
This PR improves correctness and stays more in line with what the xenial branch provides.
Applying these changes results in proper 720p support with adequate performance and visual appearance.

In addition to that, workaround/fix the issue of having the Screencasting object not disconnect itself from Mir
properly, resuling in a hang during the destruction of MirConnection (waiting for pending commands to be processed).