### PR TITLE
src & tests: Use single buffer for screencasting

### DIFF
--- a/src/ac/mir/screencast.cpp
+++ b/src/ac/mir/screencast.cpp
@@ -133,7 +133,7 @@ bool Screencast::Setup(const video::DisplayOutput &output) {
 
     mir_screencast_spec_set_pixel_format(spec, pixel_format);
     mir_screencast_spec_set_mirror_mode(spec, mir_mirror_mode_vertical);
-    mir_screencast_spec_set_number_of_buffers(spec, 2);
+    mir_screencast_spec_set_number_of_buffers(spec, 1);
 
     screencast_ = mir_screencast_create_sync(spec);
     mir_screencast_spec_release(spec);

--- a/tests/ac/mir/screencast_tests.cpp
+++ b/tests/ac/mir/screencast_tests.cpp
@@ -303,7 +303,7 @@ TEST(Screencast, ScreencastCreationFails) {
     EXPECT_CALL(*mir, mir_screencast_spec_set_mirror_mode(mir_spec, mir_mirror_mode_vertical))
             .Times(1);
 
-    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 2))
+    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 1))
             .Times(1);
 
     EXPECT_CALL(*mir, mir_screencast_create_sync(mir_spec))
@@ -395,7 +395,7 @@ TEST(Screencast, ScreencastDoesNotProvideBufferStream) {
     EXPECT_CALL(*mir, mir_screencast_spec_set_mirror_mode(mir_spec, mir_mirror_mode_vertical))
             .Times(1);
 
-    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 2))
+    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 1))
             .Times(1);
 
     auto mir_screencast = reinterpret_cast<MirScreencast*>(2);
@@ -502,7 +502,7 @@ TEST(Screencast, DoesSwapBuffersAndReturnsCurrentBuffer) {
     EXPECT_CALL(*mir, mir_screencast_spec_set_mirror_mode(mir_spec, mir_mirror_mode_vertical))
             .Times(1);
 
-    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 2))
+    EXPECT_CALL(*mir, mir_screencast_spec_set_number_of_buffers(mir_spec, 1))
             .Times(1);
 
     auto mir_screencast = reinterpret_cast<MirScreencast*>(2);


### PR DESCRIPTION
Screencasting waits for buffers synchronously, and the compositor
framebuffer is triple-buffered. This means there is no benefit in
allocating and waiting for 2 buffers during screencast.

Improves performance and latency on the Pixel 3a.