### PR TITLE
treewide: Quality improvements and 1080p support

### DIFF
--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -43,7 +43,7 @@ static constexpr int32_t kOMXVideoControlRateConstant = 2;
 // it provides.
 static constexpr int32_t kAnyFramerate = -1;
 // Default is a bitrate of 5 MBit/s
-static constexpr int32_t kDefaultBitrate = 5000000;
+static constexpr int32_t kDefaultBitrate = 15000000;
 // By default send an I frame every 15 seconds which is the
 // same Android currently configures in its WiFi Display code path.
 static constexpr std::chrono::seconds kDefaultIFrameInterval{15};

--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -105,7 +105,16 @@ public:
         if (!buffer_)
             return;
 
-        media_buffer_destroy(buffer_);
+        const auto ref_count = media_buffer_get_refcount(buffer_);
+
+        // If someone has set a reference on the buffer we just have to
+        // release it here and the other one will take care about actually
+        // destroying it.
+        if (ref_count > 0)
+            media_buffer_release(buffer_);
+        else
+            media_buffer_destroy(buffer_);
+
     }
 
     static MediaSourceBuffer::Ptr Create(MediaBufferWrapper *buffer) {

--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -242,11 +242,9 @@ bool H264Encoder::Configure(const Config &config) {
     if (config.constraint_set > 0)
         media_message_set_int32(format, kFormatKeyConstraintSet, config.constraint_set);
 
-#if 0
     // FIXME we need to find a way to check if the encoder supports prepending
     // SPS/PPS to the buffers it is producing or if we have to manually do that
     media_message_set_int32(format, kFormatKeyPrependSpsPpstoIdrFrames, 1);
-#endif
 
     auto source = media_source_create();
     if (!source) {

--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -105,16 +105,7 @@ public:
         if (!buffer_)
             return;
 
-        const auto ref_count = media_buffer_get_refcount(buffer_);
-
-        // If someone has set a reference on the buffer we just have to
-        // release it here and the other one will take care about actually
-        // destroying it.
-        if (ref_count > 0)
-            media_buffer_release(buffer_);
-        else
-            media_buffer_destroy(buffer_);
-
+        media_buffer_destroy(buffer_);
     }
 
     static MediaSourceBuffer::Ptr Create(MediaBufferWrapper *buffer) {

--- a/src/ac/basesourcemediamanager.cpp
+++ b/src/ac/basesourcemediamanager.cpp
@@ -67,9 +67,11 @@ std::vector<wds::H264VideoCodec> BaseSourceMediaManager::GetH264VideoCodecs() {
         wds::RateAndResolutionsBitmap vesa_rr;
         wds::RateAndResolutionsBitmap hh_rr;
 
-        // We only support 720p here for now as that is our best performing
-        // resolution with regard of all other bits in the pipeline. Eventually
-        // we will add 60 Hz here too but for now only everything up to 30 Hz.
+        cea_rr.set(wds::CEA1920x1080p60);
+        cea_rr.set(wds::CEA1920x1080p30);
+        cea_rr.set(wds::CEA1920x1080p25);
+        cea_rr.set(wds::CEA1920x1080p24);
+
         cea_rr.set(wds::CEA1280x720p60);
         cea_rr.set(wds::CEA1280x720p30);
         cea_rr.set(wds::CEA1280x720p25);

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -380,10 +380,8 @@ TEST_F(H264EncoderFixture, CorrectConfiguration) {
             .Times(1);
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("i-frame-interval"), config.i_frame_interval))
             .Times(1);
-#if 0
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("prepend-sps-pps-to-idr-frames"), 1))
             .Times(1);
-#endif
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("profile-idc"), 1))
             .Times(1);
     EXPECT_CALL(*mock, media_message_set_int32(format_message, StrEq("level-idc"), 2))

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -176,7 +176,7 @@ TEST_F(H264EncoderFixture, ValidDefaultConfiguration) {
 
     const auto config = encoder->DefaultConfiguration();
     EXPECT_EQ(-1, config.framerate);
-    EXPECT_EQ(5000000, config.bitrate);
+    EXPECT_EQ(15000000, config.bitrate);
     EXPECT_EQ(15, config.i_frame_interval);
     EXPECT_EQ(0, config.intra_refresh_mode);
     EXPECT_EQ(0, config.width);

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -747,10 +747,6 @@ TEST_F(H264EncoderFixture, ExecuteProvidesBuffers) {
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(0), Return(true)));
 
-    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
-            .Times(1)
-            .WillRepeatedly(Return(0));
-
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);
 
@@ -810,10 +806,6 @@ TEST_F(H264EncoderFixture, HandsBuffersWithCodecSpecificDataBack) {
     EXPECT_CALL(*mock, media_meta_data_find_int32(meta_data, 2, _))
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(1 /* marks this as a buffer with CSD */), Return(true)));
-
-    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
-            .Times(1)
-            .WillRepeatedly(Return(0));
 
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -747,6 +747,10 @@ TEST_F(H264EncoderFixture, ExecuteProvidesBuffers) {
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(0), Return(true)));
 
+    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
+            .Times(1)
+            .WillRepeatedly(Return(0));
+
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);
 
@@ -806,6 +810,10 @@ TEST_F(H264EncoderFixture, HandsBuffersWithCodecSpecificDataBack) {
     EXPECT_CALL(*mock, media_meta_data_find_int32(meta_data, 2, _))
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(1 /* marks this as a buffer with CSD */), Return(true)));
+
+    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
+            .Times(1)
+            .WillRepeatedly(Return(0));
 
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);


### PR DESCRIPTION
- Increase bitrate for the encoder to produce higher quality frames
- Enable 1080p resolutions, including 60fps
- Reenable SPS & PPS frames to counter blank frames between renders