### PR TITLE
h264encoder: Clean up various MediaMetaDataWrapper objects

### DIFF
--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -387,15 +387,14 @@ MediaBufferWrapper* H264Encoder::PackBuffer(const ac::video::Buffer::Ptr &input_
 
     media_buffer_set_return_callback(buffer, &H264Encoder::OnBufferReturned, this);
 
-#if 0
     // We need to put a reference on the buffer here if we want the
     // callback we set above being called.
     media_buffer_ref(buffer);
-#endif
 
     auto meta = media_buffer_get_meta_data(buffer);
     const auto key_time = media_meta_data_get_key_id(MEDIA_META_DATA_KEY_TIME);
     media_meta_data_set_int64(meta, key_time, timestamp);
+    media_meta_data_release(meta);
 
     pending_buffers_.push_back(BufferItem{input_buffer, buffer});
 

--- a/src/ac/android/h264encoder.cpp
+++ b/src/ac/android/h264encoder.cpp
@@ -105,6 +105,7 @@ public:
         if (!buffer_)
             return;
 
+        media_meta_data_release(meta_data);
         const auto ref_count = media_buffer_get_refcount(buffer_);
 
         // If someone has set a reference on the buffer we just have to
@@ -120,6 +121,7 @@ public:
     static MediaSourceBuffer::Ptr Create(MediaBufferWrapper *buffer) {
         const auto sp = std::shared_ptr<MediaSourceBuffer>(new MediaSourceBuffer);
         sp->buffer_ = buffer;
+        sp->meta_data = media_buffer_get_meta_data(buffer);;
         sp->ExtractTimestamp();
         return sp;
     }
@@ -138,7 +140,6 @@ public:
 
 private:
     void ExtractTimestamp() {
-        const auto meta_data = media_buffer_get_meta_data(buffer_);
         if (!meta_data)
             return;
 
@@ -151,6 +152,7 @@ private:
 
 private:
     MediaBufferWrapper *buffer_;
+    MediaMetaDataWrapper *meta_data;
 };
 
 video::BaseEncoder::Config H264Encoder::DefaultConfiguration() {
@@ -466,6 +468,7 @@ bool H264Encoder::DoesBufferContainCodecConfig(MediaBufferWrapper *buffer) {
     uint32_t key_is_codec_config = media_meta_data_get_key_id(MEDIA_META_DATA_KEY_IS_CODEC_CONFIG);
     int32_t is_codec_config = 0;
     media_meta_data_find_int32(meta_data, key_is_codec_config, &is_codec_config);
+    media_meta_data_release(meta_data);
     return static_cast<bool>(is_codec_config);
 }
 

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -113,9 +113,8 @@ public:
         EXPECT_CALL(*mock, media_meta_data_create())
                 .Times(1)
                 .WillRepeatedly(Return(meta_data));
-        EXPECT_CALL(*mock, media_meta_data_release(meta_data))
-                .Times(1)
-                .WillOnce(Invoke([](MediaMetaDataWrapper *meta) { delete meta; }));
+        EXPECT_CALL(*mock, media_meta_data_release(_))
+                .Times(AtLeast(0));
         EXPECT_CALL(*mock, media_meta_data_set_cstring(meta_data, _, _))
                 .Times(AtLeast(0));
         EXPECT_CALL(*mock, media_meta_data_set_int32(meta_data, _, _))

--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -584,10 +584,8 @@ TEST_F(H264EncoderFixture, ReturnsPackedBufferAndReleaseProperly) {
             .Times(1)
             .WillRepeatedly(Return(mbuf_data));
 
-#if 0
     EXPECT_CALL(*mock, media_buffer_ref(mbuf))
             .Times(1);
-#endif
 
     EXPECT_CALL(*mock, media_buffer_get_meta_data(mbuf))
             .Times(1);
@@ -595,6 +593,8 @@ TEST_F(H264EncoderFixture, ReturnsPackedBufferAndReleaseProperly) {
             .Times(1)
             .WillRepeatedly(Return(42));
     EXPECT_CALL(*mock, media_meta_data_set_int64(_, 42, now));
+    EXPECT_CALL(*mock, media_meta_data_release(_))
+            .Times(AtLeast(1));
 
     MediaBufferReturnCallback return_callback;
     void *return_callback_data = nullptr;


### PR DESCRIPTION
Since libhybris compatibility changes for Halium 9.0 and (https://github.com/Halium/libhybris/commit/ab4c7e3630c76f47c56caab62cf02e249647d3ff)
and possibly even before that it is necessary to clean up all the created
wrapper objects around meta data handling, otherwise they fill up memory quite fast.
    
Do exactly that for both the encoded buffer and the one checking
for whether the codec config has been established.
