### PR TITLE
src & test: Destroy MediaBuffer after it's been sent

### DIFF
--- a/tests/ac/android/h264encoder_tests.cpp
+++ b/tests/ac/android/h264encoder_tests.cpp
@@ -618,7 +618,7 @@ TEST_F(H264EncoderFixture, ReturnsPackedBufferAndReleaseProperly) {
     EXPECT_CALL(*buffer_delegate, OnBufferFinished(input_buffer))
             .Times(1);
 
-    EXPECT_CALL(*mock, media_buffer_release(output_buffer))
+    EXPECT_CALL(*mock, media_buffer_destroy(output_buffer))
             .Times(1);
 
     return_callback(output_buffer, return_callback_data);
@@ -744,10 +744,6 @@ TEST_F(H264EncoderFixture, ExecuteProvidesBuffers) {
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(0), Return(true)));
 
-    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
-            .Times(1)
-            .WillRepeatedly(Return(0));
-
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);
 
@@ -807,10 +803,6 @@ TEST_F(H264EncoderFixture, HandsBuffersWithCodecSpecificDataBack) {
     EXPECT_CALL(*mock, media_meta_data_find_int32(meta_data, 2, _))
             .Times(1)
             .WillRepeatedly(DoAll(SetArgPointee<2>(1 /* marks this as a buffer with CSD */), Return(true)));
-
-    EXPECT_CALL(*mock, media_buffer_get_refcount(input_buffer))
-            .Times(1)
-            .WillRepeatedly(Return(0));
 
     EXPECT_CALL(*mock, media_buffer_destroy(input_buffer))
             .Times(1);


### PR DESCRIPTION
Newer versions of Android expose a refcounting problem where MediaBufferBase
objects tied to an observer don't get released properly, possibly because of
signalBufferReturned not getting called.

As there is always one last remaining reference on the buffer
and we're ultimately done processing it, just steal & destroy it.

Requires this change as a prerequisite, as implicit release() will never release
the resource in question with broken refcounting: https://github.com/Halium/libhybris/pull/13